### PR TITLE
Run qodana codescanner only when java files are updated.

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -2,9 +2,13 @@ name: Qodana
 on:
   workflow_dispatch:
   pull_request:
+    paths:
+      - '**.java'
     branches:
       - main
   push:
+    paths:
+      - '**.java'
     branches:
       - main
       - 'releases/*'


### PR DESCRIPTION
This should update the Qodana workflow to fix #48.