### PR TITLE
Adds tests for ClientHandler

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,12 @@
             <artifactId>log4j-core</artifactId>
             <version>2.17.1</version>
         </dependency>
+        <dependency>
+            <groupId>io.github.hakky54</groupId>
+            <artifactId>logcaptor</artifactId>
+            <version>2.7.8</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/src/test/java/org/fungover/storm/client/ClientHandlerTest.java
+++ b/src/test/java/org/fungover/storm/client/ClientHandlerTest.java
@@ -8,22 +8,22 @@ import java.io.*;
 import java.net.Socket;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.mockito.Mockito.mock;
 
 
 class ClientHandlerTest {
 
     @Test
-    void shouldNotThrowExceptionWhenThereIsASuccessfulConnection() throws IOException {
-        OutputStream outputStream = new ByteArrayOutputStream();
-        InputStream inputStream = new ByteArrayInputStream("hello world".getBytes());
+    void shouldNotLogAnErrorWhenThereIsASuccessfulConnection() throws IOException {
+        LogCaptor logCaptor = LogCaptor.forName("SERVER");
         Socket socket = mock(Socket.class);
-        Mockito.when(socket.getOutputStream()).thenReturn(outputStream);
-        Mockito.when(socket.getInputStream()).thenReturn(inputStream);
+        Mockito.when(socket.getOutputStream()).thenReturn(new ByteArrayOutputStream());
+        Mockito.when(socket.getInputStream()).thenReturn(new ByteArrayInputStream("Hello Storm!".getBytes()));
         ClientHandler clientHandler = new ClientHandler(socket);
 
-        assertThatNoException().isThrownBy(clientHandler::run);
+        clientHandler.run();
+
+        assertThat(logCaptor.getErrorLogs()).isEmpty();
     }
 
     @Test

--- a/src/test/java/org/fungover/storm/client/ClientHandlerTest.java
+++ b/src/test/java/org/fungover/storm/client/ClientHandlerTest.java
@@ -1,13 +1,16 @@
 package org.fungover.storm.client;
 
+import nl.altindag.log.LogCaptor;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.io.*;
 import java.net.Socket;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.mockito.Mockito.mock;
+
 
 class ClientHandlerTest {
 
@@ -21,6 +24,18 @@ class ClientHandlerTest {
         ClientHandler clientHandler = new ClientHandler(socket);
 
         assertThatNoException().isThrownBy(clientHandler::run);
+    }
+
+    @Test
+    void shouldLogAnErrorWhenThereIsAConnectionError() throws IOException {
+        LogCaptor logCaptor = LogCaptor.forName("SERVER");
+        Socket socket = new Socket();
+        ClientHandler clientHandler = new ClientHandler(socket);
+
+        socket.close();
+        clientHandler.run();
+
+        assertThat(logCaptor.getErrorLogs()).hasSize(1);
     }
 
 }

--- a/src/test/java/org/fungover/storm/client/ClientHandlerTest.java
+++ b/src/test/java/org/fungover/storm/client/ClientHandlerTest.java
@@ -1,0 +1,26 @@
+package org.fungover.storm.client;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.io.*;
+import java.net.Socket;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.Mockito.mock;
+
+class ClientHandlerTest {
+
+    @Test
+    void shouldNotThrowExceptionWhenThereIsASuccessfulConnection() throws IOException {
+        OutputStream outputStream = new ByteArrayOutputStream();
+        InputStream inputStream = new ByteArrayInputStream("hello world".getBytes());
+        Socket socket = mock(Socket.class);
+        Mockito.when(socket.getOutputStream()).thenReturn(outputStream);
+        Mockito.when(socket.getInputStream()).thenReturn(inputStream);
+        ClientHandler clientHandler = new ClientHandler(socket);
+
+        assertThatNoException().isThrownBy(clientHandler::run);
+    }
+
+}


### PR DESCRIPTION
Closes #42 

Initially I tried to test if the method would throw an I/O Exception or not but I soon realised that the method itself never throws an Exception because it would already have been handled by the `try-catch` block in ClientHandler. I have therefore tested whether or not an error message has been logged in order to determine if an exception has been thrown. 
Any input or improvements would be greatly appreciated 🙂.