### PR TITLE
Update maven.yml with checkout for badges branch

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -36,7 +36,7 @@ jobs:
       id: jacoco
       uses: cicirello/jacoco-badge-generator@v2
       with:
-          bagdes-directory: badges
+          badges-directory: badges
           generate-branches-badge: true
           generate-summary: true
           fail-if-coverage-less-than: 50

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,18 +16,27 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Checkout badges branch dedicated to storing badges only
+      uses: actions/checkout@v2
+      with:
+        ref: badges
+        path: badges
+        
     - name: Set up JDK 17
       uses: actions/setup-java@v2
       with:
         java-version: '17'
         distribution: 'temurin'
         cache: maven
+
     - name: Build with Maven
       run: mvn -B test --file pom.xml
+      
     - name: Generate JaCoCo Badge
       id: jacoco
       uses: cicirello/jacoco-badge-generator@v2
       with:
+          bagdes-directory: badges
           generate-branches-badge: true
           generate-summary: true
           fail-if-coverage-less-than: 50


### PR DESCRIPTION
Solves #76 

Creates a new .svg file as a image. The images are stored in a dedicated branch called "branch". In that way the images doesn't require two review approvals for each push. 

