### PR TITLE
 Delete HttpResponseStatusCodes.java and statusCode field

### DIFF
--- a/src/main/java/org/fungover/storm/client/ClientHandler.java
+++ b/src/main/java/org/fungover/storm/client/ClientHandler.java
@@ -42,9 +42,8 @@ public class ClientHandler implements Runnable {
             out.close();
             clientSocket.close();
         } catch (IOException e) {
-            HttpResponseStatusCodes statusCode = new HttpResponseStatusCodes();
             if (e.getMessage().contains("500"))
-                LOGGER.error(statusCode.getError500());
+                LOGGER.error("500 Internal Server Error\r\n");
             else
                 LOGGER.error(e.getMessage());
         }

--- a/src/main/java/org/fungover/storm/client/ClientHandler.java
+++ b/src/main/java/org/fungover/storm/client/ClientHandler.java
@@ -16,8 +16,7 @@ import java.nio.file.Files;
 public class ClientHandler implements Runnable {
     private static final Logger LOGGER = LogManager.getLogger("CLIENT_HANDLER");
     private final Socket clientSocket;
-    private HttpResponseStatusCodes statusCode;
-    private FileRequestHandler fileRequestHandler;
+    private final FileRequestHandler fileRequestHandler;
 
     public ClientHandler(Socket socket, FileRequestHandler fileRequestHandler) {
         this.clientSocket = socket;
@@ -43,7 +42,7 @@ public class ClientHandler implements Runnable {
             out.close();
             clientSocket.close();
         } catch (IOException e) {
-            statusCode = new HttpResponseStatusCodes();
+            HttpResponseStatusCodes statusCode = new HttpResponseStatusCodes();
             if (e.getMessage().contains("500"))
                 LOGGER.error(statusCode.getError500());
             else

--- a/src/main/java/org/fungover/storm/client/HttpResponseStatusCodes.java
+++ b/src/main/java/org/fungover/storm/client/HttpResponseStatusCodes.java
@@ -1,9 +1,0 @@
-package org.fungover.storm.client;
-
-public class HttpResponseStatusCodes {
-    static final String error500 = "500 Internal Server Error\r\n";
-
-    String getError500() {
-        return error500;
-    }
-}

--- a/src/main/java/org/fungover/storm/config/Configuration.java
+++ b/src/main/java/org/fungover/storm/config/Configuration.java
@@ -9,26 +9,23 @@ public class Configuration {
         return port;
     }
 
-    public Configuration setPort(int port) {
+    public void setPort(int port) {
         this.port = port;
-        return this;
     }
 
     public String getWebroot() {
         return webroot;
     }
 
-    public Configuration setWebroot(String webroot) {
+    public void setWebroot(String webroot) {
         this.webroot = webroot;
-        return this;
     }
 
     public String getType() {
         return type;
     }
 
-    public String setType(String type) {
+    public void setType(String type) {
         this.type = type;
-        return type;
     }
 }


### PR DESCRIPTION
In my opnion we should remove this class because the only reason we had it in the first place was because of the string.